### PR TITLE
Added to_regex attribute as a shorhand

### DIFF
--- a/crocs.py
+++ b/crocs.py
@@ -77,6 +77,10 @@ class RegexOperator(object):
 
         # print('Fail with:\n', ' '.join((self.invalid_data() 
         # for ind in xrange(count))))
+        
+    @property
+    def to_regex(self):
+        return self.seed()[0]
 
     def __str__(self):
         pass


### PR DESCRIPTION
Hi there, 

Love what you did with this regex nightmare! Much more human friendly :-)

The one thing missing is a shorthand to get the compiled regex string. The solution suggested by @EnricoGiampieri in #3 seems the most straightforward (except I added that to the base class `RegexOperator` instead of `Pattern` so that all classes inherit from it).